### PR TITLE
Replace . by _ in HttpMonitorTransport.java

### DIFF
--- a/src/main/java/org/graylog2/plugin/httpmonitor/HttpMonitorTransport.java
+++ b/src/main/java/org/graylog2/plugin/httpmonitor/HttpMonitorTransport.java
@@ -213,17 +213,17 @@ public class HttpMonitorTransport implements Transport {
                 long time;
                 Map<String, Object> eventdata = Maps.newHashMap();
                 eventdata.put("version", "1.1");
-                eventdata.put("_http.monitor.url", config.getUrl());
+                eventdata.put("_http_monitor_url", config.getUrl());
                 eventdata.put("_label", config.getLabel());
                 try {
                     Response response = requestBuilder.execute().get();
                     long endTime = System.currentTimeMillis();
                     time = endTime - startTime;
                     eventdata.put("host", response.getUri().getHost());
-                    eventdata.put("_http.monitor.status", response.getStatusCode());
-                    eventdata.put("_http.monitor.statusLine", response.getStatusText());
+                    eventdata.put("_http_monitor_status", response.getStatusCode());
+                    eventdata.put("_http_monitor_statusLine", response.getStatusText());
                     String responseBodyStr = new String(response.getResponseBodyAsBytes());
-                    eventdata.put("_http.monitor.responseSize", responseBodyStr.length());
+                    eventdata.put("_http_monitor_responseSize", responseBodyStr.length());
                     if (config.isLogResponseBody()) {
                         eventdata.put("full_message", responseBodyStr);
                     }
@@ -243,24 +243,24 @@ public class HttpMonitorTransport implements Transport {
                 } catch (ExecutionException e) {
                     eventdata.put("host", new URL(config.getUrl()).getHost());
                     eventdata.put("short_message", "Request failed :" + e.getMessage());
-                    eventdata.put("_http.monitor.responseSize", 0);
+                    eventdata.put("_http_monitor_responseSize", 0);
                     long endTime = System.currentTimeMillis();
                     time = endTime - startTime;
                     //In case of connection timeout we get an execution exception with root cause as timeoutexception
                     if (e.getCause() instanceof TimeoutException) {
                         LOGGER.debug("Timeout while executing request for URL " + config.getUrl(), e);
-                        eventdata.put("_http.monitor.status", 998);
+                        eventdata.put("_http_monitor_status", 998);
                     } else if (e.getCause() instanceof ConnectException) {
                         //In case of connect exception we get an execution exception with root cause as connectexception
                         LOGGER.debug("Exception while executing request for URL " + config.getUrl(), e);
-                        eventdata.put("_http.monitor.status", 999);
+                        eventdata.put("_http_monitor_status", 999);
                     } else {
                         //Any other exception..
                         LOGGER.debug("Exception while executing request for URL " + config.getUrl(), e);
-                        eventdata.put("_http.monitor.status", 997);
+                        eventdata.put("_http_monitor_status", 997);
                     }
                 }
-                eventdata.put("_http.monitor.responseTime", time);
+                eventdata.put("_http_monitor_responseTime", time);
 
                 //publish to graylog server
                 ByteArrayOutputStream byteStream = new ByteArrayOutputStream();


### PR DESCRIPTION
Replace . by _

> org.graylog2.plugin.Message - Keys must not contain a "." character! Ignoring field "http.monitor.responseSize"="248157" in message [073f6a10-ea5e-11e5-ad8b-62df949bdde0

Graylog 2.0 does not accept . in keys apparently
